### PR TITLE
fix: correctly resolve `${USER}` in `m2f_cfg_file` path

### DIFF
--- a/ros/planner/src/viplanner_node.py
+++ b/ros/planner/src/viplanner_node.py
@@ -1029,7 +1029,7 @@ if __name__ == "__main__":
 
     # model save path
     args.model_save = os.path.join(pack_path, args.model_save)
-    args.m2f_config_path = os.path.join(pack_path, args.m2f_cfg_file)
+    args.m2f_config_path = os.path.join(pack_path, os.path.expandvars(args.m2f_cfg_file))
     args.m2f_model_path = os.path.join(pack_path, args.m2f_model_path)
 
     node = VIPlannerNode(args)


### PR DESCRIPTION
# Description

Bug Description:

```bash
Traceback (most recent call last):
  File "/home/ubuntu/workspaces/viplanner_ws/njust/viplanner/catkin_ws/devel/lib/viplanner_node/viplanner_node.py", line 15, in <module>
    exec(compile(fh.read(), python_script, 'exec'), context)
  File "/home/ubuntu/workspaces/viplanner_ws/njust/viplanner/ros/planner/src/viplanner_node.py", line 1036, in <module>
    node = VIPlannerNode(args)
  File "/home/ubuntu/workspaces/viplanner_ws/njust/viplanner/ros/planner/src/viplanner_node.py", line 65, in __init__
    self.m2f_inference = Mask2FormerInference(
  File "/home/ubuntu/workspaces/viplanner_ws/njust/viplanner/ros/planner/src/m2f_inference.py", line 31, in __init__
    self.model = init_detector(config_file, checkpoint_file, device="cpu")
  File "/home/ubuntu/.local/lib/python3.8/site-packages/mmdet/apis/inference.py", line 53, in init_detector
    config = Config.fromfile(config)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/mmengine/config/config.py", line 455, in fromfile
    lazy_import is None and not Config._is_lazy_import(filename):
  File "/home/ubuntu/.local/lib/python3.8/site-packages/mmengine/config/config.py", line 1651, in _is_lazy_import
    with open(filename, encoding='utf-8') as f:
FileNotFoundError: [Errno 2] No such file or directory: '/home/${USER}/.local/lib/python3.8/site-packages/mmdet/.mim/configs/mask2former/mask2former_r50_8xb2-lsj-50e_coco-panoptic.py'
```

This PR updated the path resolution logic to use `os.path.expandvars` for expanding environment variables like `${USER}` in `m2f_cfg_file`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./formatter.sh`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
